### PR TITLE
Pin greenkeeper-lockfile to 1.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "danger": "3.0.5",
     "eclint": "2.6.0",
     "eslint": "4.15.0",
-    "greenkeeper-lockfile": "^1.12.0",
+    "greenkeeper-lockfile": "1.12.0",
     "markdownlint-cli": "^0.6.0"
   },
   "eslintConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1004,7 +1004,7 @@ graceful-fs@^4.0.0, graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
 
-greenkeeper-lockfile@^1.12.0:
+greenkeeper-lockfile@1.12.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/greenkeeper-lockfile/-/greenkeeper-lockfile-1.12.0.tgz#e2cbb6529ecb2af3dabcf30f027549dceb5fbd6e"
   dependencies:


### PR DESCRIPTION
Dependencies should always be pinned.